### PR TITLE
Added clearer dotnet documentation and fixed up other READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features:
 
 ## How to run locally
 
-This sample includes [6 server implementations](server/README.md) in our most popular languages. Follow the steps below to run locally.
+This sample includes [7 server implementations](server/README.md) in our most popular languages. Follow the steps below to run locally.
 
 **1. Clone and configure the sample**
 

--- a/server/README.md
+++ b/server/README.md
@@ -10,3 +10,5 @@ Pick the language you are most comfortable in and follow the instructions in the
 * [Ruby (Sinatra)](ruby/README.md)
 * [PHP (Slim)](php/README.md)
 * [Java (Spark)](java/README.md)
+* [Go](go/README.md)
+* [C# (ASP.Net)](dotnet/README.md)

--- a/server/dotnet/README.md
+++ b/server/dotnet/README.md
@@ -1,9 +1,25 @@
 # Stripe Billing
-## Set up subscriptions sample
+### Set up subscriptions sample
 
-1. Fill out the following values in the [appsettings.json](appsettings.json) file - `StripePublishableKey`, `StripeSecretKey`, and `SubscriptionPlanId`.
-2. Set `STATIC_DIR` environment variable to `../../client`.
-3. Run the application using `dotnet run`.
-4. Navigate to `https://localhost:4242` and verify the sample is running properly.
-5. To receive and process webhook events, run `stripe listen --forward-to https://localhost:4242/webhook --skip-verify`.
-6. Fill in `StripeWebhookSecret` with the webhook signing secret the Stripe CLI returns.
+## Install .NET Core
+
+If you do not already have dotnet installed, download it from here: https://dotnet.microsoft.com/download.
+
+## Configure the sample
+
+1. Navigate to the Stripe Dashboard to retrieve the API Keys necessary to run the sample.
+2. Create a [plan](https://stripe.com/docs/billing/subscriptions/products-and-plans) using the Dashboard or the Stripe CLI.
+3. Fill out the following values in the [appsettings.Development.json](appsettings.Development.json) file.
+    1. `StripePublishableKey`
+    2. `StripeSecretKey`
+    3. `SubscriptionPlanId`
+4. Set the `STATIC_DIR` environment variable to `../../client`.
+    - Note: This is only because the various sample server implementations use the same client code.
+
+## Run the application
+
+1. If testing webhooks locally, make sure to have the [Stripe CLI](https://stripe.com/docs/stripe-cli) installed.
+    - Run `stripe listen --forward-to https://localhost:4242/webhook --skip-verify`.
+    - Fill in `StripeWebhookSecret` with the webhook signing secret the Stripe CLI returns.
+2. Run the sample application using `dotnet run`.
+3. Navigate to `https://localhost:4242` and verify the sample is running properly.


### PR DESCRIPTION
r? @ctrudeau-stripe @adreyfus-stripe 

- Split the dotnet documentation up between installation / configuration / running the sample.
- Fixed some discrepancies in the other READMEs.

Let me know what you think!
