### PR TITLE
Add subscription method for DotNet server sample

### DIFF
--- a/server/dotnet/Controllers/SubscriptionsController.cs
+++ b/server/dotnet/Controllers/SubscriptionsController.cs
@@ -67,6 +67,14 @@ public class SubscriptionsController : Controller
         return subscription;
     }
 
+    [HttpPost("subscription")]
+    public async Task<ActionResult<Subscription>> RetrieveSubscriptionAsync([FromBody] SubscriptionRetrieveRequest request)
+    {
+        var subscriptionService = new SubscriptionService(this.client);
+
+        return await subscriptionService.GetAsync(request.SubscriptionId);
+    }
+
     [HttpPost("webhook")]
     public async Task<IActionResult> ProcessWebhookEvent()
     {

--- a/server/dotnet/Models/SubscriptionRetrieveRequest.cs
+++ b/server/dotnet/Models/SubscriptionRetrieveRequest.cs
@@ -1,0 +1,7 @@
+using Newtonsoft.Json;
+
+public class SubscriptionRetrieveRequest
+{
+    [JsonProperty("subscriptionId")]
+    public string SubscriptionId { get; set; }
+}


### PR DESCRIPTION
r? @ctrudeau-stripe 

Fixing issue https://github.com/stripe-samples/set-up-subscriptions/issues/17 .

Missed adding this the first time around, didn't encounter while testing since didn't test the path where the payment intent status was `requires_actions` or `requires_payment_method`.

After looking through the sample code, I believe this should actually be a GET request since its just retrieving the subscription object - however I did not want to go in and modify the rest of the samples within this PR.

How tested:

- removed the condition in client.js that results in calling this action and verified everything worked as expected.
- tested with a 3D Secure test card number