### PR TITLE
Dawn migrate to prices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ STRIPE_SECRET_KEY=sk_12345
 STRIPE_WEBHOOK_SECRET=whsec_1234
 
 # Billing variables 
-SUBSCRIPTION_PLAN_ID=plan_12345
+SUBSCRIPTION_PRICE_ID=price_12345
 
 # Environment variables 
 STATIC_DIR=../../client

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ STRIPE_SECRET_KEY=<replace-with-your-secret-key>
 
 **2. Create Products and Plans on Stripe** 
 
-This sample requires a [Plan](https://stripe.com/docs/api/plans/object) ID to create the subscription. Products and Plans are objects on Stripe that you use to model a subscription. 
+This sample requires a [Price](https://stripe.com/docs/api/prices/object) ID to create the subscription. Products and Prices are objects on Stripe that you use to model a subscription. 
 
-You can create Products and Plans [in the Dashboard](https://dashboard.stripe.com/products) or with the [API](https://stripe.com/docs/api/plans/create). Create a Plan to run this sample and add it to your `.env`.
+You can create Products and Prices [in the Dashboard](https://dashboard.stripe.com/products) or with the [API](https://stripe.com/docs/api/prices/create). Create a Price to run this sample and add it to your `.env`.
 
 **3. Follow the server instructions on how to run:**
 

--- a/server/dotnet/Configuration/StripeOptions.cs
+++ b/server/dotnet/Configuration/StripeOptions.cs
@@ -3,5 +3,5 @@ public class StripeOptions
     public string StripePublishableKey { get; set; }
     public string StripeSecretKey { get; set; }
     public string StripeWebhookSecret { get; set; }
-    public string SubscriptionPlanId { get; set; }
+    public string SubscriptionPriceId { get; set; }
 }

--- a/server/dotnet/Controllers/SubscriptionsController.cs
+++ b/server/dotnet/Controllers/SubscriptionsController.cs
@@ -54,7 +54,7 @@ public class SubscriptionsController : Controller
             {
                 new SubscriptionItemOptions
                 {
-                    Plan = this.options.Value.SubscriptionPlanId,
+                    Price = this.options.Value.SubscriptionPriceId,
                 },
             },
             Customer = customer.Id,

--- a/server/dotnet/README.md
+++ b/server/dotnet/README.md
@@ -1,23 +1,13 @@
-# Stripe Billing
-### Set up subscriptions sample
+# Stripe Billing charging for subscriptions
 
-## Install .NET Core
+## Requirements
+- [.NET Core()]https://dotnet.microsoft.com/download)
 
-If you do not already have dotnet installed, download it from here: https://dotnet.microsoft.com/download.
+## How to run
 
-## Configure the sample
+1. Run the application
+```
+dotnet run
+```
 
-1. Navigate to the Stripe Dashboard to retrieve the API Keys necessary to run the sample.
-2. Create a [plan](https://stripe.com/docs/billing/subscriptions/products-and-plans) using the Dashboard or the Stripe CLI.
-3. Fill out the values in the [.env.example](../../.env.example) file.
-4. Run the following command: `cp .env.example server/dotnet/.env` to move the .env file into this directory.
-5. Set the `STATIC_DIR` environment variable to `../../client`.
-    - Note: This is only because the various sample server implementations use the same client code.
-
-## Run the application
-
-1. If testing webhooks locally, make sure to have the [Stripe CLI](https://stripe.com/docs/stripe-cli) installed.
-    - Run `stripe listen --forward-to https://localhost:4242/webhook --skip-verify`.
-    - Fill in `StripeWebhookSecret` with the webhook signing secret the Stripe CLI returns.
-2. Run the sample application using `dotnet run`.
-3. Navigate to `https://localhost:4242` and verify the sample is running properly.
+2. Go to `https://localhost:4242` or `http://localhost:42424` in your browser to see the demo

--- a/server/dotnet/Startup.cs
+++ b/server/dotnet/Startup.cs
@@ -24,7 +24,7 @@ namespace sample
                 stripeOptions.StripePublishableKey = Environment.GetEnvironmentVariable("STRIPE_PUBLISHABLE_KEY");
                 stripeOptions.StripeSecretKey = Environment.GetEnvironmentVariable("STRIPE_SECRET_KEY");
                 stripeOptions.StripeWebhookSecret = Environment.GetEnvironmentVariable("STRIPE_WEBHOOK_SECRET");
-                stripeOptions.SubscriptionPlanId = Environment.GetEnvironmentVariable("SUBSCRIPTION_PLAN_ID");
+                stripeOptions.SubscriptionPriceId = Environment.GetEnvironmentVariable("SUBSCRIPTION_PRICE_ID");
             });
 
             // Serialize JSON back in a way the sample JavaScript expects.

--- a/server/dotnet/sample.csproj
+++ b/server/dotnet/sample.csproj
@@ -8,6 +8,6 @@
     <PackageReference Include="DotNetEnv" Version="1.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Stripe.net" Version="34.18.0" />
+    <PackageReference Include="Stripe.net" Version="36.8.1" />
   </ItemGroup>
 </Project>

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -36,7 +36,7 @@ type PublicKey struct {
 }
 
 func main() {
-  err := godotenv.Load("../../.env")
+  err := godotenv.Load(".env")
 
   if err != nil {
     fmt.Println("Error loading .env file")
@@ -79,7 +79,7 @@ func main() {
 
     items := []*stripe.SubscriptionItemsParams{
       {
-        Plan: stripe.String(os.Getenv("SUBSCRIPTION_PLAN_ID")),
+        Price: stripe.String(os.Getenv("SUBSCRIPTION_PRICE_ID")),
       },
     }
     params := &stripe.SubscriptionParams{

--- a/server/java/pom.xml
+++ b/server/java/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.stripe</groupId>
             <artifactId>stripe-java</artifactId>
-            <version>10.0.2</version>
+            <version>19.8.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.cdimascio</groupId>

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -42,7 +42,7 @@ app.post('/create-customer', async (req, res) => {
   // own internal representation of a customer, if you have one.
   const subscription = await stripe.subscriptions.create({
     customer: customer.id,
-    items: [{ plan: process.env.SUBSCRIPTION_PLAN_ID }],
+    items: [{ price: process.env.SUBSCRIPTION_PRICE_ID }],
     expand: ['latest_invoice.payment_intent']
   });
   res.send(subscription);

--- a/server/php/index.php
+++ b/server/php/index.php
@@ -39,7 +39,7 @@ $app->get('/public-key', function (Request $request, Response $response, array $
 });
 
 $app->post('/create-customer', function (Request $request, Response $response, array $args) {  
-  $plan_id = getenv('SUBSCRIPTION_PLAN_ID');
+  $price_id = getenv('SUBSCRIPTION_PRICE_ID');
   $body = json_decode($request->getBody());
   
   # This creates a new Customer and attaches the PaymentMethod in one API call.
@@ -57,7 +57,7 @@ $app->post('/create-customer', function (Request $request, Response $response, a
     "customer" => $customer['id'],
     "items" => [
       [
-        "plan" => $plan_id,
+        "price" => $price_id,
       ],
     ], 
     "expand" => ['latest_invoice.payment_intent']

--- a/server/python/README.md
+++ b/server/python/README.md
@@ -11,7 +11,7 @@
 
 ```
 python3 -m venv /path/to/new/virtual/environment
-source /path/to/new/virtual/environment/venv/bin/activate
+source /path/to/new/virtual/environment/bin/activate
 ```
 
 2. Install dependencies

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -58,7 +58,7 @@ def create_customer():
             customer=customer.id,
             items=[
                 {
-                    "plan": os.getenv("SUBSCRIPTION_PLAN_ID"),
+                    "price": os.getenv("SUBSCRIPTION_PRICE_ID"),
                 },
             ],
             expand=["latest_invoice.payment_intent"]

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -1,5 +1,6 @@
 require 'stripe'
 require 'sinatra'
+require "sinatra/reloader" if development?
 require 'dotenv'
 
 # Replace if using a different env file or config
@@ -43,7 +44,7 @@ post '/create-customer' do
     customer: customer.id,
     items: [
       {
-        plan: ENV['SUBSCRIPTION_PLAN_ID']
+        price: ENV['SUBSCRIPTION_PRICE_ID']
       }
     ],
     expand: ['latest_invoice.payment_intent']


### PR DESCRIPTION
Migrated references to 'plans' to new the Prices API.  Also fixed a few random things I saw: 

- server/dotnet/README.MD was inconsistent in the information it provided compared to other server specific READMEs, so made it more consistent
- migrated the Java API calls to use typed params

Someone might want to confirm these 2 fixes to make sure the changes I needed weren't just due to something being misconfigured in my environment
- path to load the .env file w/in the go server
- path to activate the virtual env w/in python
